### PR TITLE
Implement GET /api/assembly/all endpoint (TASK-2.3)

### DIFF
--- a/handlers/assemblyHandler.js
+++ b/handlers/assemblyHandler.js
@@ -1,0 +1,25 @@
+const { getAllSurveys } = require('../services/assemblySvc');
+const { checkLogin } = require('./loginHandler');
+
+/**
+ * Handler for GET /api/assembly/all
+ * Lists all current and past surveys.
+ */
+async function getAllSurveysHandler(req, res) {
+  try {
+    await checkLogin(req);
+
+    console.log('=== getAllSurveysHandler');
+    const surveys = await getAllSurveys();
+
+    res.status(200).json(surveys);
+  } catch (error) {
+    if (error.message.includes('Authorization') || error.message.includes('Token') || error.message.includes('Application')) {
+      return res.status(401).send(error.message);
+    }
+    console.error('getAllSurveysHandler Error:', error);
+    res.status(500).json({ code: "500", error: error.message });
+  }
+}
+
+module.exports = { getAllSurveysHandler };

--- a/handlers/assemblyHandler.test.js
+++ b/handlers/assemblyHandler.test.js
@@ -1,0 +1,80 @@
+const request = require('supertest');
+const express = require('express');
+const { newRouter } = require('./router');
+const admin = require('firebase-admin');
+const { checkLogin } = require('./loginHandler');
+
+// Mock admin
+jest.mock('firebase-admin', () => {
+  const getMock = jest.fn();
+  const collectionMock = jest.fn(() => ({
+    get: getMock
+  }));
+  const firestoreMock = jest.fn(() => ({
+    collection: collectionMock
+  }));
+  return {
+    firestore: firestoreMock
+  };
+});
+
+// Mock checkLogin to bypass authentication
+jest.mock('./loginHandler', () => ({
+  ...jest.requireActual('./loginHandler'),
+  checkLogin: jest.fn().mockResolvedValue(true)
+}));
+
+const app = express();
+app.use(newRouter());
+
+describe('GET /api/assembly/all', () => {
+  it('should return 200 and list of surveys', async () => {
+    const mockSurveys = [
+      {
+        id: 'survey1',
+        data: () => ({
+          question: 'Question 1',
+          status: 'OPEN',
+          createDate: {
+            toDate: () => new Date('2026-06-18T10:00:00Z')
+          },
+          options: [
+            { text: 'Option 1', votesCount: 1, coefficientVotes: 0.5 }
+          ]
+        })
+      }
+    ];
+
+    admin.firestore().collection().get.mockResolvedValue(mockSurveys);
+
+    const res = await request(app)
+      .get('/api/assembly/all')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Application', 'ur-admin-site');
+
+    expect(res.statusCode).toEqual(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0]).toEqual({
+      id: 'survey1',
+      question: 'Question 1',
+      status: 'OPEN',
+      createdAt: '2026-06-18T10:00:00.000Z',
+      options: [
+        { text: 'Option 1', votesCount: 1, coefficientVotes: 0.5 }
+      ]
+    });
+  });
+
+  it('should return 500 when firestore fails', async () => {
+    admin.firestore().collection().get.mockRejectedValue(new Error('Firestore error'));
+
+    const res = await request(app)
+      .get('/api/assembly/all')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Application', 'ur-admin-site');
+
+    expect(res.statusCode).toEqual(500);
+    expect(res.body.code).toEqual('500');
+  });
+});

--- a/handlers/router.js
+++ b/handlers/router.js
@@ -5,6 +5,7 @@ const { fcmHandler } = require('./fcmHandler');
 const { healthHandler } = require('./healthHandler');
 const { firebaseDataHandler } = require('./firebaseDatabaseHandler');
 const { activeUserStatsHandler } = require('./bigqueryHandler');
+const { getAllSurveysHandler } = require('./assemblyHandler');
 
 function newRouter() {
   const router = express.Router();
@@ -22,6 +23,7 @@ function newRouter() {
   router.get('/api/health', healthHandler);
   router.get('/api/firebase-data/:tokenName', firebaseDataHandler);
   router.get('/api/stats/active-users', activeUserStatsHandler);
+  router.get('/api/assembly/all', getAllSurveysHandler);
 
   return router;
 }

--- a/services/assemblySvc.js
+++ b/services/assemblySvc.js
@@ -1,0 +1,41 @@
+const admin = require('firebase-admin');
+
+/**
+ * Fetches all surveys from Firestore and maps them to the Survey interface.
+ * @returns {Promise<Array>} Array of surveys.
+ */
+async function getAllSurveys() {
+  const db = admin.firestore();
+  const surveysSnapshot = await db.collection('surveys').get();
+
+  const surveys = [];
+  surveysSnapshot.forEach(doc => {
+    const data = doc.data();
+
+    // Map Firestore data to Survey interface
+    const survey = {
+      id: doc.id,
+      question: data.question || '',
+      status: data.status || 'CLOSED',
+      createdAt: data.createDate && typeof data.createDate.toDate === 'function'
+        ? data.createDate.toDate().toISOString()
+        : (data.createDate || null),
+      options: data.options ? data.options.map(opt => ({
+        text: opt.text || opt.value || '',
+        votesCount: opt.votesCount !== undefined ? opt.votesCount : (opt.votes !== undefined ? opt.votes : 0),
+        coefficientVotes: opt.coefficientVotes || 0
+      })) : []
+    };
+
+    // Include summary fields if they exist
+    if (data.mostVotedOption) survey.mostVotedOption = data.mostVotedOption;
+    if (data.mostVotedVotes !== undefined) survey.mostVotedVotes = data.mostVotedVotes;
+    if (data.mostVotedCoefficient !== undefined) survey.mostVotedCoefficient = data.mostVotedCoefficient;
+
+    surveys.push(survey);
+  });
+
+  return surveys;
+}
+
+module.exports = { getAllSurveys };


### PR DESCRIPTION
I have implemented the `GET /api/assembly/all` endpoint as requested in TASK-2.3. 

The implementation includes:
- A new service `services/assemblySvc.js` that retrieves all documents from the Firestore `surveys` collection. It correctly maps Firestore data to the `Survey` interface defined in `models/interfaces.ts`, including converting Firestore Timestamps to ISO strings and handling field name variations.
- A new handler `handlers/assemblyHandler.js` that validates the request using `checkLogin` and invokes the service.
- Registration of the `/api/assembly/all` route in `handlers/router.js`.
- A suite of integration tests in `handlers/assemblyHandler.test.js` covering success and error scenarios.

All tests passed successfully.

---
*PR created automatically by Jules for task [9301645045732774271](https://jules.google.com/task/9301645045732774271) started by @nano871022*