### PR TITLE
Implement PUT /api/assembly/create endpoint

### DIFF
--- a/handlers/assemblyHandler.js
+++ b/handlers/assemblyHandler.js
@@ -1,4 +1,4 @@
-const { getAllSurveys } = require('../services/assemblySvc');
+const { getAllSurveys, createSurvey } = require('../services/assemblySvc');
 const { checkLogin } = require('./loginHandler');
 
 /**
@@ -22,4 +22,31 @@ async function getAllSurveysHandler(req, res) {
   }
 }
 
-module.exports = { getAllSurveysHandler };
+/**
+ * Handler for PUT /api/assembly/create
+ * Initializes and persists a new survey question.
+ */
+async function createSurveyHandler(req, res) {
+  try {
+    await checkLogin(req);
+
+    console.log('=== createSurveyHandler');
+    const { question, options } = req.body;
+
+    if (!question || !options || !Array.isArray(options)) {
+      return res.status(400).json({ code: "400", error: "Missing required fields: question and options (array)" });
+    }
+
+    const newSurvey = await createSurvey(question, options);
+
+    res.status(201).json(newSurvey);
+  } catch (error) {
+    if (error.message.includes('Authorization') || error.message.includes('Token') || error.message.includes('Application')) {
+      return res.status(401).send(error.message);
+    }
+    console.error('createSurveyHandler Error:', error);
+    res.status(500).json({ code: "500", error: error.message });
+  }
+}
+
+module.exports = { getAllSurveysHandler, createSurveyHandler };

--- a/handlers/assemblyHandler.test.js
+++ b/handlers/assemblyHandler.test.js
@@ -7,12 +7,17 @@ const { checkLogin } = require('./loginHandler');
 // Mock admin
 jest.mock('firebase-admin', () => {
   const getMock = jest.fn();
+  const addMock = jest.fn();
   const collectionMock = jest.fn(() => ({
-    get: getMock
+    get: getMock,
+    add: addMock
   }));
   const firestoreMock = jest.fn(() => ({
     collection: collectionMock
   }));
+  firestoreMock.FieldValue = {
+    serverTimestamp: jest.fn(() => 'mock-timestamp')
+  };
   return {
     firestore: firestoreMock
   };
@@ -73,6 +78,73 @@ describe('GET /api/assembly/all', () => {
       .get('/api/assembly/all')
       .set('Authorization', 'Bearer valid-token')
       .set('Application', 'ur-admin-site');
+
+    expect(res.statusCode).toEqual(500);
+    expect(res.body.code).toEqual('500');
+  });
+});
+
+describe('PUT /api/assembly/create', () => {
+  it('should return 201 and the created survey', async () => {
+    const mockDocRef = { id: 'new-survey-id' };
+    admin.firestore().collection().add.mockResolvedValue(mockDocRef);
+
+    const payload = {
+      question: 'Should we approve the new budget?',
+      options: [
+        { value: 'Yes', votes: 0 },
+        { value: 'No', votes: 0 }
+      ]
+    };
+
+    const res = await request(app)
+      .put('/api/assembly/create')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Application', 'ur-admin-site')
+      .send(payload);
+
+    expect(res.statusCode).toEqual(201);
+    expect(res.body.id).toEqual('new-survey-id');
+    expect(res.body.question).toEqual(payload.question);
+    expect(res.body.status).toEqual('OPEN');
+    expect(res.body.options.length).toBe(2);
+    expect(res.body.options[0].text).toEqual('Yes');
+    expect(res.body.options[0].votesCount).toEqual(0);
+
+    expect(admin.firestore().collection).toHaveBeenCalledWith('surveys');
+    expect(admin.firestore().collection().add).toHaveBeenCalledWith({
+      question: payload.question,
+      status: 'OPEN',
+      createDate: 'mock-timestamp',
+      timeUsed: '0',
+      options: payload.options
+    });
+  });
+
+  it('should return 400 when missing required fields', async () => {
+    const res = await request(app)
+      .put('/api/assembly/create')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Application', 'ur-admin-site')
+      .send({ question: 'Only question' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.error).toContain('Missing required fields');
+  });
+
+  it('should return 500 when firestore fails', async () => {
+    admin.firestore().collection().add.mockRejectedValue(new Error('Firestore error'));
+
+    const payload = {
+      question: 'Question',
+      options: [{ value: 'Opt 1', votes: 0 }]
+    };
+
+    const res = await request(app)
+      .put('/api/assembly/create')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Application', 'ur-admin-site')
+      .send(payload);
 
     expect(res.statusCode).toEqual(500);
     expect(res.body.code).toEqual('500');

--- a/handlers/router.js
+++ b/handlers/router.js
@@ -5,7 +5,7 @@ const { fcmHandler } = require('./fcmHandler');
 const { healthHandler } = require('./healthHandler');
 const { firebaseDataHandler } = require('./firebaseDatabaseHandler');
 const { activeUserStatsHandler } = require('./bigqueryHandler');
-const { getAllSurveysHandler } = require('./assemblyHandler');
+const { getAllSurveysHandler, createSurveyHandler } = require('./assemblyHandler');
 
 function newRouter() {
   const router = express.Router();
@@ -24,6 +24,7 @@ function newRouter() {
   router.get('/api/firebase-data/:tokenName', firebaseDataHandler);
   router.get('/api/stats/active-users', activeUserStatsHandler);
   router.get('/api/assembly/all', getAllSurveysHandler);
+  router.put('/api/assembly/create', createSurveyHandler);
 
   return router;
 }

--- a/services/assemblySvc.js
+++ b/services/assemblySvc.js
@@ -38,4 +38,39 @@ async function getAllSurveys() {
   return surveys;
 }
 
-module.exports = { getAllSurveys };
+/**
+ * Creates a new survey in Firestore.
+ * @param {string} question The survey question.
+ * @param {Array} options The survey options.
+ * @returns {Promise<Object>} The created survey metadata.
+ */
+async function createSurvey(question, options) {
+  const db = admin.firestore();
+
+  const newSurveyData = {
+    question: question,
+    status: 'OPEN',
+    createDate: admin.firestore.FieldValue.serverTimestamp(),
+    timeUsed: "0",
+    options: options.map(opt => ({
+      value: opt.value || '',
+      votes: opt.votes !== undefined ? opt.votes : 0
+    }))
+  };
+
+  const docRef = await db.collection('surveys').add(newSurveyData);
+
+  return {
+    id: docRef.id,
+    question: newSurveyData.question,
+    status: newSurveyData.status,
+    createdAt: new Date().toISOString(),
+    options: newSurveyData.options.map(opt => ({
+      text: opt.value,
+      votesCount: opt.votes,
+      coefficientVotes: 0
+    }))
+  };
+}
+
+module.exports = { getAllSurveys, createSurvey };


### PR DESCRIPTION
Implemented the `PUT /api/assembly/create` endpoint as specified in TASK-2.4. This endpoint allows for the creation of new surveys in the Firestore `surveys` collection. It includes authentication checks, request body validation, and maps the internal data structures to maintain compatibility with the frontend `Survey` interface. Full test coverage has been added and verified.

---
*PR created automatically by Jules for task [8793769094071563387](https://jules.google.com/task/8793769094071563387) started by @nano871022*