### PR TITLE
Implement endpoint POST /api/assembly/restart

### DIFF
--- a/handlers/assemblyHandler.js
+++ b/handlers/assemblyHandler.js
@@ -120,10 +120,46 @@ async function getCoefficientHandler(req, res) {
   }
 }
 
+/**
+ * Handler for POST /api/assembly/restart
+ * Resets an existing survey back to an open status and wipes previous vote tabulations.
+ */
+async function restartSurveyHandler(req, res) {
+  try {
+    await checkLogin(req);
+
+    const { id } = req.body;
+    console.log(`=== restartSurveyHandler: Restarting survey ID: ${id}`);
+
+    if (!id) {
+      return res.status(400).json({ code: "400", error: "Missing required field: id" });
+    }
+
+    const updatedSurvey = await assemblySvc.restartSurvey(id);
+
+    if (!updatedSurvey) {
+      return res.status(404).json({ code: "404", error: "Survey not found" });
+    }
+
+    res.status(200).json({
+      code: "200",
+      message: "Survey restarted successfully",
+      survey: updatedSurvey
+    });
+  } catch (error) {
+    if (error.message.includes('Authorization') || error.message.includes('Token') || error.message.includes('Application')) {
+      return res.status(401).send(error.message);
+    }
+    console.error('restartSurveyHandler Error:', error);
+    res.status(500).json({ code: "500", error: error.message });
+  }
+}
+
 module.exports = {
   getAttendeesHandler,
   getAllSurveysHandler,
   getVotesHandler,
   getCoefficientHandler,
-  createSurveyHandler
+  createSurveyHandler,
+  restartSurveyHandler
 };

--- a/handlers/assemblyHandler.test.js
+++ b/handlers/assemblyHandler.test.js
@@ -5,7 +5,8 @@ const {
   getAllSurveysHandler,
   getVotesHandler,
   getCoefficientHandler,
-  createSurveyHandler
+  createSurveyHandler,
+  restartSurveyHandler
 } = require('./assemblyHandler');
 const { checkLogin } = require('./loginHandler');
 const assemblySvc = require('../services/assemblySvc');
@@ -19,7 +20,8 @@ jest.mock('../services/assemblySvc', () => ({
   getAllSurveys: jest.fn(),
   getSurveyById: jest.fn(),
   getCoefficientData: jest.fn(),
-  createSurvey: jest.fn()
+  createSurvey: jest.fn(),
+  restartSurvey: jest.fn()
 }));
 
 const app = express();
@@ -29,6 +31,7 @@ app.get('/api/assembly/all', getAllSurveysHandler);
 app.get('/api/assembly/votes', getVotesHandler);
 app.get('/api/assembly/coefficient', getCoefficientHandler);
 app.put('/api/assembly/create', createSurveyHandler);
+app.post('/api/assembly/restart', restartSurveyHandler);
 
 describe('Assembly Handlers', () => {
   beforeEach(() => {
@@ -192,6 +195,56 @@ describe('Assembly Handlers', () => {
         .send({ question: 'Q' });
 
       expect(res.statusCode).toEqual(400);
+    });
+  });
+
+  describe('POST /api/assembly/restart', () => {
+    it('should return 200 and updated survey when authenticated and id is provided', async () => {
+      const mockUpdatedSurvey = {
+        id: 'survey123',
+        status: 'OPEN',
+        options: [{ text: 'Option 1', votesCount: 0, coefficientVotes: 0 }]
+      };
+      checkLogin.mockResolvedValue(true);
+      assemblySvc.restartSurvey.mockResolvedValue(mockUpdatedSurvey);
+
+      const res = await request(app)
+        .post('/api/assembly/restart')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({ id: 'survey123' });
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.message).toBe('Survey restarted successfully');
+      expect(res.body.survey).toEqual(mockUpdatedSurvey);
+      expect(assemblySvc.restartSurvey).toHaveBeenCalledWith('survey123');
+    });
+
+    it('should return 400 when id is missing', async () => {
+      checkLogin.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/api/assembly/restart')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.error).toContain('Missing required field: id');
+    });
+
+    it('should return 404 when survey is not found', async () => {
+      checkLogin.mockResolvedValue(true);
+      assemblySvc.restartSurvey.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post('/api/assembly/restart')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({ id: 'nonexistent' });
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body.error).toContain('Survey not found');
     });
   });
 });

--- a/handlers/router.js
+++ b/handlers/router.js
@@ -10,7 +10,8 @@ const {
   getAllSurveysHandler,
   getVotesHandler,
   getCoefficientHandler,
-  createSurveyHandler
+  createSurveyHandler,
+  restartSurveyHandler
 } = require('./assemblyHandler');
 
 
@@ -37,6 +38,7 @@ function newRouter() {
   router.get('/api/assembly/votes', getVotesHandler);
   router.get('/api/assembly/attendees', getAttendeesHandler);
   router.get('/api/assembly/coefficient', getCoefficientHandler);
+  router.post('/api/assembly/restart', restartSurveyHandler);
 
   return router;
 }

--- a/services/assemblySvc.js
+++ b/services/assemblySvc.js
@@ -168,10 +168,48 @@ async function getCoefficientData() {
   };
 }
 
+/**
+ * Restarts a survey by resetting its status and clearing all votes and statistics.
+ * @param {string} id The survey ID.
+ * @returns {Promise<Object|null>} The updated survey object or null if not found.
+ */
+async function restartSurvey(id) {
+  const db = admin.firestore();
+  const docRef = db.collection('surveys').doc(id);
+  const doc = await docRef.get();
+
+  if (!doc.exists) {
+    return null;
+  }
+
+  const data = doc.data();
+  const resetOptions = (data.options || []).map(opt => {
+    const newOpt = { ...opt };
+    if (newOpt.votes !== undefined) newOpt.votes = 0;
+    if (newOpt.votesCount !== undefined) newOpt.votesCount = 0;
+    newOpt.coefficientVotes = 0;
+    return newOpt;
+  });
+
+  const updateData = {
+    status: 'OPEN',
+    options: resetOptions,
+    mostVotedOption: admin.firestore.FieldValue.delete(),
+    mostVotedVotes: admin.firestore.FieldValue.delete(),
+    mostVotedCoefficient: admin.firestore.FieldValue.delete()
+  };
+
+  await docRef.update(updateData);
+
+  const updatedDoc = await docRef.get();
+  return mapSurveyDoc(updatedDoc);
+}
+
 module.exports = {
   getAttendeesMetrics,
   getAllSurveys,
   getSurveyById,
   getCoefficientData,
-  createSurvey
+  createSurvey,
+  restartSurvey
 };


### PR DESCRIPTION
Implemented the `POST /api/assembly/restart` endpoint which allows resetting an existing survey back to an open status and clearing previous vote tabulations and summary statistics. The changes include updates to the assembly service for Firestore interactions, the request handler with authentication, and the API router. Unit tests were also added to ensure correct behavior and error handling.

---
*PR created automatically by Jules for task [16876943830632174363](https://jules.google.com/task/16876943830632174363) started by @nano871022*