### PR TITLE
Implement POST /api/assembly/close endpoint

### DIFF
--- a/handlers/assemblyHandler.js
+++ b/handlers/assemblyHandler.js
@@ -155,11 +155,43 @@ async function restartSurveyHandler(req, res) {
   }
 }
 
+/**
+ * Handler for POST /api/assembly/close
+ * Formally freezes voting inputs on a survey, calculate final metrics, and compile results.
+ */
+async function closeVotesHandler(req, res) {
+  try {
+    await checkLogin(req);
+
+    const { id } = req.body;
+    console.log(`=== closeVotesHandler: Closing survey ID: ${id}`);
+
+    if (!id) {
+      return res.status(400).json({ code: "400", error: "Missing required field: id" });
+    }
+
+    const closedSurvey = await assemblySvc.closeSurvey(id);
+
+    if (!closedSurvey) {
+      return res.status(404).json({ code: "404", error: "Survey not found" });
+    }
+
+    res.status(200).json(closedSurvey);
+  } catch (error) {
+    if (error.message.includes('Authorization') || error.message.includes('Token') || error.message.includes('Application')) {
+      return res.status(401).send(error.message);
+    }
+    console.error('closeVotesHandler Error:', error);
+    res.status(500).json({ code: "500", error: error.message });
+  }
+}
+
 module.exports = {
   getAttendeesHandler,
   getAllSurveysHandler,
   getVotesHandler,
   getCoefficientHandler,
   createSurveyHandler,
-  restartSurveyHandler
+  restartSurveyHandler,
+  closeVotesHandler
 };

--- a/handlers/assemblyHandler.test.js
+++ b/handlers/assemblyHandler.test.js
@@ -6,7 +6,8 @@ const {
   getVotesHandler,
   getCoefficientHandler,
   createSurveyHandler,
-  restartSurveyHandler
+  restartSurveyHandler,
+  closeVotesHandler
 } = require('./assemblyHandler');
 const { checkLogin } = require('./loginHandler');
 const assemblySvc = require('../services/assemblySvc');
@@ -21,7 +22,8 @@ jest.mock('../services/assemblySvc', () => ({
   getSurveyById: jest.fn(),
   getCoefficientData: jest.fn(),
   createSurvey: jest.fn(),
-  restartSurvey: jest.fn()
+  restartSurvey: jest.fn(),
+  closeSurvey: jest.fn()
 }));
 
 const app = express();
@@ -32,6 +34,7 @@ app.get('/api/assembly/votes', getVotesHandler);
 app.get('/api/assembly/coefficient', getCoefficientHandler);
 app.put('/api/assembly/create', createSurveyHandler);
 app.post('/api/assembly/restart', restartSurveyHandler);
+app.post('/api/assembly/close', closeVotesHandler);
 
 describe('Assembly Handlers', () => {
   beforeEach(() => {
@@ -239,6 +242,55 @@ describe('Assembly Handlers', () => {
 
       const res = await request(app)
         .post('/api/assembly/restart')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({ id: 'nonexistent' });
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body.error).toContain('Survey not found');
+    });
+  });
+
+  describe('POST /api/assembly/close', () => {
+    it('should return 200 and closed survey when authenticated and id is provided', async () => {
+      const mockClosedSurvey = {
+        id: 'survey123',
+        status: 'CLOSED',
+        mostVotedOption: 'Option 1'
+      };
+      checkLogin.mockResolvedValue(true);
+      assemblySvc.closeSurvey.mockResolvedValue(mockClosedSurvey);
+
+      const res = await request(app)
+        .post('/api/assembly/close')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({ id: 'survey123' });
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual(mockClosedSurvey);
+      expect(assemblySvc.closeSurvey).toHaveBeenCalledWith('survey123');
+    });
+
+    it('should return 400 when id is missing', async () => {
+      checkLogin.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/api/assembly/close')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.error).toContain('Missing required field: id');
+    });
+
+    it('should return 404 when survey is not found', async () => {
+      checkLogin.mockResolvedValue(true);
+      assemblySvc.closeSurvey.mockResolvedValue(null);
+
+      const res = await request(app)
+        .post('/api/assembly/close')
         .set('Authorization', 'Bearer valid-token')
         .set('Application', 'ur-admin-site')
         .send({ id: 'nonexistent' });

--- a/handlers/router.js
+++ b/handlers/router.js
@@ -11,7 +11,8 @@ const {
   getVotesHandler,
   getCoefficientHandler,
   createSurveyHandler,
-  restartSurveyHandler
+  restartSurveyHandler,
+  closeVotesHandler
 } = require('./assemblyHandler');
 
 
@@ -39,6 +40,7 @@ function newRouter() {
   router.get('/api/assembly/attendees', getAttendeesHandler);
   router.get('/api/assembly/coefficient', getCoefficientHandler);
   router.post('/api/assembly/restart', restartSurveyHandler);
+  router.post('/api/assembly/close', closeVotesHandler);
 
   return router;
 }

--- a/services/assemblySvc.js
+++ b/services/assemblySvc.js
@@ -205,11 +205,109 @@ async function restartSurvey(id) {
   return mapSurveyDoc(updatedDoc);
 }
 
+/**
+ * Closes a survey, aggregates votes, and calculates final results.
+ * @param {string} id The survey ID.
+ * @returns {Promise<Object|null>} The updated survey object or null if not found.
+ */
+async function closeSurvey(id) {
+  const db = admin.firestore();
+  const docRef = db.collection('surveys').doc(id);
+  const doc = await docRef.get();
+
+  if (!doc.exists) {
+    return null;
+  }
+
+  const data = doc.data();
+  const now = new Date();
+  let timeUsed = "0";
+
+  if (data.createDate) {
+    const createDate = data.createDate.toDate ? data.createDate.toDate() : new Date(data.createDate);
+    const diffMs = now - createDate;
+    timeUsed = Math.floor(diffMs / 1000).toString();
+  }
+
+  // Fetch all votes for this survey
+  const votesSnapshot = await db.collection('votes').where('surveyId', '==', id).get();
+
+  // Fetch present attendees to map their coefficients
+  const attendeesSnapshot = await db.collection('attendees').where('present', '==', true).get();
+  const attendeeCoefficients = {};
+  attendeesSnapshot.forEach(aDoc => {
+    attendeeCoefficients[aDoc.id] = aDoc.data().coefficient || 0;
+  });
+
+  // Aggregation maps
+  const optionVotesCount = {};
+  const optionCoefficientSum = {};
+
+  // Initialize maps with existing options
+  const options = data.options || [];
+  options.forEach(opt => {
+    const val = opt.value || opt.text;
+    optionVotesCount[val] = 0;
+    optionCoefficientSum[val] = 0;
+  });
+
+  // Count votes and sum coefficients
+  votesSnapshot.forEach(vDoc => {
+    const vData = vDoc.data();
+    const val = vData.value;
+    const attendeeId = vData.attendeeId;
+
+    if (optionVotesCount[val] !== undefined) {
+      optionVotesCount[val]++;
+      optionCoefficientSum[val] += (attendeeCoefficients[attendeeId] || 0);
+    }
+  });
+
+  // Update options array and find the winner
+  let mostVotedOption = "";
+  let mostVotedVotes = -1;
+  let mostVotedCoefficient = 0;
+
+  const updatedOptions = options.map(opt => {
+    const val = opt.value || opt.text;
+    const count = optionVotesCount[val] || 0;
+    const coeff = Math.round((optionCoefficientSum[val] || 0) * 100) / 100;
+
+    if (count > mostVotedVotes) {
+      mostVotedVotes = count;
+      mostVotedOption = val;
+      mostVotedCoefficient = coeff;
+    }
+
+    const updatedOpt = { ...opt };
+    if (updatedOpt.votes !== undefined) updatedOpt.votes = count;
+    if (updatedOpt.votesCount !== undefined) updatedOpt.votesCount = count;
+    updatedOpt.coefficientVotes = coeff;
+
+    return updatedOpt;
+  });
+
+  const updateData = {
+    status: 'CLOSED',
+    timeUsed: timeUsed,
+    options: updatedOptions,
+    mostVotedOption: mostVotedOption,
+    mostVotedVotes: mostVotedVotes,
+    mostVotedCoefficient: mostVotedCoefficient
+  };
+
+  await docRef.update(updateData);
+
+  const updatedDoc = await docRef.get();
+  return mapSurveyDoc(updatedDoc);
+}
+
 module.exports = {
   getAttendeesMetrics,
   getAllSurveys,
   getSurveyById,
   getCoefficientData,
   createSurvey,
-  restartSurvey
+  restartSurvey,
+  closeSurvey
 };


### PR DESCRIPTION
Implemented the `POST /api/assembly/close` endpoint to formally freeze voting on a survey and calculate final results.

Key changes:
- **Service Layer**: Added `closeSurvey` in `services/assemblySvc.js` to handle vote aggregation, weighted coefficient calculation, and determination of the winning option.
- **Handler Layer**: Created `closeVotesHandler` in `handlers/assemblyHandler.js` with request validation and authentication.
- **Routing**: Registered the new POST route in `handlers/router.js`.
- **Testing**: Added comprehensive unit tests in `handlers/assemblyHandler.test.js` covering success and error scenarios.

All tests passed successfully.

---
*PR created automatically by Jules for task [12927291956558648168](https://jules.google.com/task/12927291956558648168) started by @nano871022*