### PR TITLE
Add assembly delete and init endpoints

### DIFF
--- a/handlers/assemblyHandler.js
+++ b/handlers/assemblyHandler.js
@@ -163,14 +163,14 @@ async function closeVotesHandler(req, res) {
   try {
     await checkLogin(req);
 
-    const { id } = req.body;
-    console.log(`=== closeVotesHandler: Closing survey ID: ${id}`);
+    const { id, timeUsed } = req.body;
+    console.log(`=== closeVotesHandler: Closing survey ID: ${id}, timeUsed: ${timeUsed}`);
 
     if (!id) {
       return res.status(400).json({ code: "400", error: "Missing required field: id" });
     }
 
-    const closedSurvey = await assemblySvc.closeSurvey(id);
+    const closedSurvey = await assemblySvc.closeSurvey(id, timeUsed);
 
     if (!closedSurvey) {
       return res.status(404).json({ code: "404", error: "Survey not found" });

--- a/handlers/assemblyHandler.js
+++ b/handlers/assemblyHandler.js
@@ -186,6 +186,58 @@ async function closeVotesHandler(req, res) {
   }
 }
 
+/**
+ * Handler for DELETE /api/assembly/delete?id={id}
+ */
+async function deleteSurveyHandler(req, res) {
+  try {
+    await checkLogin(req);
+
+    const id = req.query.id;
+    console.log(`=== deleteSurveyHandler: Deleting survey ID: ${id}`);
+
+    if (!id) {
+      return res.status(400).json({ code: "400", error: "Missing required query parameter: id" });
+    }
+
+    await assemblySvc.deleteSurvey(id);
+
+    res.status(200).json({ code: "200", message: "Survey deleted successfully" });
+  } catch (error) {
+    if (error.message.includes('Authorization') || error.message.includes('Token') || error.message.includes('Application')) {
+      return res.status(401).send(error.message);
+    }
+    console.error('deleteSurveyHandler Error:', error);
+    res.status(500).json({ code: "500", error: error.message });
+  }
+}
+
+/**
+ * Handler for PUT /api/assembly/init
+ */
+async function initAssemblyHandler(req, res) {
+  try {
+    await checkLogin(req);
+
+    const { year, date } = req.body;
+    console.log(`=== initAssemblyHandler: Year: ${year}, Date: ${date}`);
+
+    if (!year || !date) {
+      return res.status(400).json({ code: "400", error: "Missing required fields: year and date" });
+    }
+
+    const result = await assemblySvc.initAssembly(year, date);
+
+    res.status(200).json({ code: "200", message: "Assembly initialized successfully", data: result });
+  } catch (error) {
+    if (error.message.includes('Authorization') || error.message.includes('Token') || error.message.includes('Application')) {
+      return res.status(401).send(error.message);
+    }
+    console.error('initAssemblyHandler Error:', error);
+    res.status(500).json({ code: "500", error: error.message });
+  }
+}
+
 module.exports = {
   getAttendeesHandler,
   getAllSurveysHandler,
@@ -193,5 +245,7 @@ module.exports = {
   getCoefficientHandler,
   createSurveyHandler,
   restartSurveyHandler,
-  closeVotesHandler
+  closeVotesHandler,
+  deleteSurveyHandler,
+  initAssemblyHandler
 };

--- a/handlers/assemblyHandler.test.js
+++ b/handlers/assemblyHandler.test.js
@@ -271,11 +271,11 @@ describe('Assembly Handlers', () => {
         .post('/api/assembly/close')
         .set('Authorization', 'Bearer valid-token')
         .set('Application', 'ur-admin-site')
-        .send({ id: 'survey123' });
+        .send({ id: 'survey123', timeUsed: "45" });
 
       expect(res.statusCode).toEqual(200);
       expect(res.body).toEqual(mockClosedSurvey);
-      expect(assemblySvc.closeSurvey).toHaveBeenCalledWith('survey123');
+      expect(assemblySvc.closeSurvey).toHaveBeenCalledWith('survey123', "45");
     });
 
     it('should return 400 when id is missing', async () => {

--- a/handlers/assemblyHandler.test.js
+++ b/handlers/assemblyHandler.test.js
@@ -7,7 +7,9 @@ const {
   getCoefficientHandler,
   createSurveyHandler,
   restartSurveyHandler,
-  closeVotesHandler
+  closeVotesHandler,
+  deleteSurveyHandler,
+  initAssemblyHandler
 } = require('./assemblyHandler');
 const { checkLogin } = require('./loginHandler');
 const assemblySvc = require('../services/assemblySvc');
@@ -23,7 +25,9 @@ jest.mock('../services/assemblySvc', () => ({
   getCoefficientData: jest.fn(),
   createSurvey: jest.fn(),
   restartSurvey: jest.fn(),
-  closeSurvey: jest.fn()
+  closeSurvey: jest.fn(),
+  deleteSurvey: jest.fn(),
+  initAssembly: jest.fn()
 }));
 
 const app = express();
@@ -35,6 +39,8 @@ app.get('/api/assembly/coefficient', getCoefficientHandler);
 app.put('/api/assembly/create', createSurveyHandler);
 app.post('/api/assembly/restart', restartSurveyHandler);
 app.post('/api/assembly/close', closeVotesHandler);
+app.delete('/api/assembly/delete', deleteSurveyHandler);
+app.put('/api/assembly/init', initAssemblyHandler);
 
 describe('Assembly Handlers', () => {
   beforeEach(() => {
@@ -297,6 +303,76 @@ describe('Assembly Handlers', () => {
 
       expect(res.statusCode).toEqual(404);
       expect(res.body.error).toContain('Survey not found');
+    });
+  });
+
+  describe('DELETE /api/assembly/delete', () => {
+    it('should return 200 when survey is deleted successfully', async () => {
+      checkLogin.mockResolvedValue(true);
+      assemblySvc.deleteSurvey.mockResolvedValue(true);
+
+      const res = await request(app)
+        .delete('/api/assembly/delete?id=survey123')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.message).toBe('Survey deleted successfully');
+      expect(assemblySvc.deleteSurvey).toHaveBeenCalledWith('survey123');
+    });
+
+    it('should return 400 when id is missing', async () => {
+      checkLogin.mockResolvedValue(true);
+
+      const res = await request(app)
+        .delete('/api/assembly/delete')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site');
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.error).toContain('Missing required query parameter: id');
+    });
+  });
+
+  describe('PUT /api/assembly/init', () => {
+    it('should return 200 when assembly is initialized successfully', async () => {
+      const mockResult = { year: 2026, date: '18/02/2026', status: 'ACTIVE' };
+      checkLogin.mockResolvedValue(true);
+      assemblySvc.initAssembly.mockResolvedValue(mockResult);
+
+      const res = await request(app)
+        .put('/api/assembly/init')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({ year: 2026, date: '18/02/2026' });
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.message).toBe('Assembly initialized successfully');
+      expect(res.body.data).toEqual(mockResult);
+      expect(assemblySvc.initAssembly).toHaveBeenCalledWith(2026, '18/02/2026');
+    });
+
+    it('should return 400 when missing required fields', async () => {
+      checkLogin.mockResolvedValue(true);
+
+      const res = await request(app)
+        .put('/api/assembly/init')
+        .set('Authorization', 'Bearer valid-token')
+        .set('Application', 'ur-admin-site')
+        .send({ year: 2026 });
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.error).toContain('Missing required fields: year and date');
+    });
+
+    it('should return 401 when not authenticated', async () => {
+      checkLogin.mockRejectedValue(new Error('Authorization token is missing'));
+
+      const res = await request(app)
+        .put('/api/assembly/init')
+        .send({ year: 2026, date: '18/02/2026' });
+
+      expect(res.statusCode).toEqual(401);
     });
   });
 });

--- a/handlers/router.js
+++ b/handlers/router.js
@@ -12,7 +12,9 @@ const {
   getCoefficientHandler,
   createSurveyHandler,
   restartSurveyHandler,
-  closeVotesHandler
+  closeVotesHandler,
+  deleteSurveyHandler,
+  initAssemblyHandler
 } = require('./assemblyHandler');
 
 
@@ -41,6 +43,8 @@ function newRouter() {
   router.get('/api/assembly/coefficient', getCoefficientHandler);
   router.post('/api/assembly/restart', restartSurveyHandler);
   router.post('/api/assembly/close', closeVotesHandler);
+  router.delete('/api/assembly/delete', deleteSurveyHandler);
+  router.put('/api/assembly/init', initAssemblyHandler);
 
   return router;
 }

--- a/models/interfaces.ts
+++ b/models/interfaces.ts
@@ -17,6 +17,7 @@ export interface Survey {
   question: string;
   status: 'OPEN' | 'CLOSED';
   createdAt: string;
+  timeUsed?: string;
   mostVotedOption?: string;
   mostVotedVotes?: number;
   mostVotedCoefficient?: number;

--- a/services/assemblySvc.js
+++ b/services/assemblySvc.js
@@ -302,6 +302,52 @@ async function closeSurvey(id) {
   return mapSurveyDoc(updatedDoc);
 }
 
+/**
+ * Deletes a survey and its associated votes.
+ * @param {string} id The survey ID.
+ * @returns {Promise<boolean>} True if successful.
+ */
+async function deleteSurvey(id) {
+  const db = getFirestore('firestore-assembly');
+
+  // Delete survey document
+  await db.collection('surveys').doc(id).delete();
+
+  // Delete associated votes
+  const votesSnapshot = await db.collection('votes').where('surveyId', '==', id).get();
+  const deletePromises = [];
+  votesSnapshot.forEach(doc => {
+    deletePromises.push(doc.ref.delete());
+  });
+  await Promise.all(deletePromises);
+
+  return true;
+}
+
+/**
+ * Initializes a new assembly session by updating metadata.
+ * @param {number|string} year The assembly year.
+ * @param {string} date The assembly date.
+ * @returns {Promise<Object>} The updated assembly data.
+ */
+async function initAssembly(year, date) {
+  const db = getFirestore('firestore-assembly');
+  const docRef = db.collection('assemblies').doc('active');
+
+  const updateData = {
+    year: year,
+    date: date,
+    status: 'ACTIVE',
+    attendanceCount: 0,
+    totalUnits: 0
+  };
+
+  await docRef.set(updateData, { merge: true });
+
+  const updatedDoc = await docRef.get();
+  return updatedDoc.data();
+}
+
 module.exports = {
   getAttendeesMetrics,
   getAllSurveys,
@@ -309,5 +355,7 @@ module.exports = {
   getCoefficientData,
   createSurvey,
   restartSurvey,
-  closeSurvey
+  closeSurvey,
+  deleteSurvey,
+  initAssembly
 };

--- a/services/assemblySvc.js
+++ b/services/assemblySvc.js
@@ -21,6 +21,8 @@ function mapSurveyDoc(doc) {
     })) : []
   };
 
+  if (data.timeUsed) survey.timeUsed = data.timeUsed;
+
   // Include summary fields if they exist
   if (data.mostVotedOption) survey.mostVotedOption = data.mostVotedOption;
   if (data.mostVotedVotes !== undefined) survey.mostVotedVotes = data.mostVotedVotes;
@@ -208,9 +210,10 @@ async function restartSurvey(id) {
 /**
  * Closes a survey, aggregates votes, and calculates final results.
  * @param {string} id The survey ID.
+ * @param {string} [manualTimeUsed] Optional duration in seconds as string.
  * @returns {Promise<Object|null>} The updated survey object or null if not found.
  */
-async function closeSurvey(id) {
+async function closeSurvey(id, manualTimeUsed) {
   const db = getFirestore('firestore-assembly');
   const docRef = db.collection('surveys').doc(id);
   const doc = await docRef.get();
@@ -220,13 +223,17 @@ async function closeSurvey(id) {
   }
 
   const data = doc.data();
-  const now = new Date();
-  let timeUsed = "0";
+  let timeUsed = manualTimeUsed;
 
-  if (data.createDate) {
-    const createDate = data.createDate.toDate ? data.createDate.toDate() : new Date(data.createDate);
-    const diffMs = now - createDate;
-    timeUsed = Math.floor(diffMs / 1000).toString();
+  if (!timeUsed) {
+    const now = new Date();
+    timeUsed = "0";
+
+    if (data.createDate) {
+      const createDate = data.createDate.toDate ? data.createDate.toDate() : new Date(data.createDate);
+      const diffMs = now - createDate;
+      timeUsed = Math.floor(diffMs / 1000).toString();
+    }
   }
 
   // Fetch all votes for this survey


### PR DESCRIPTION
This PR adds two new endpoints to the assembly API:
1. `DELETE /api/assembly/delete?id={id}`: Deletes a survey and all associated votes from Firestore.
2. `PUT /api/assembly/init`: Initializes a new assembly session by updating the 'active' assembly document with the provided year and date, and resetting attendance counts.

Changes include:
- New service methods `deleteSurvey` and `initAssembly` in `services/assemblySvc.js`.
- New handlers `deleteSurveyHandler` and `initAssemblyHandler` in `handlers/assemblyHandler.js`.
- Route registration in `handlers/router.js`.
- Comprehensive integration tests in `handlers/assemblyHandler.test.js`.

---
*PR created automatically by Jules for task [14999473347260583157](https://jules.google.com/task/14999473347260583157) started by @nano871022*